### PR TITLE
Add checking for SNID to setup.py installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(name='pySNID',
       author_email='benjamin_stahl@berkeley.edu',
       license='MIT',
       packages=['pySNID'],
-      install_requires=['numpy']
+      install_requires=['numpy'],
       cmd_class = {
           'install' : CustomInstallCommand,
-      }
+      },
     )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,16 @@
 from setuptools import setup
+from setuptools.command.install import install
+from distutils.errors import DistutilsSetupError
+import shutil
+
+class CustomInstallCommand(install):
+    """Customized setuptools install command - checks for SNID installation."""
+    def run(self):
+        snid_install = shutil.which("snid")
+        if snid_install is not None:
+            install.run(self)
+        else:
+            raise DistutilsSetupError("Cannot find SNID, aborting pySNID installation")
 
 setup(name='pySNID',
       version='0.1.dev0',
@@ -9,4 +21,7 @@ setup(name='pySNID',
       license='MIT',
       packages=['pySNID'],
       install_requires=['numpy']
+      cmd_class = {
+          'install' : CustomInstallCommand,
+      }
     )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='pySNID',
       license='MIT',
       packages=['pySNID'],
       install_requires=['numpy'],
-      cmd_class = {
+      cmdclass = {
           'install' : CustomInstallCommand,
       },
     )


### PR DESCRIPTION
I've added to the `setup.py` file an override of the `install` command that first checks if `SNID` is installed. If it is not installed, the installation is aborted and the error message `Cannot find SNID, aborting pySNID installation` is printed to the command line. If it is installed, the package is installed.